### PR TITLE
Add dependabot config to ignore example project

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+
+  - package-ecosystem: 'github-actions'
+    directory: '.github/workflows'
+    schedule:
+      interval: 'daily'


### PR DESCRIPTION
We get dependabot alerts on the example project that is not relevant for the overall project. I assume that by defining what directories/platforms to check it would not check the irrelevant stuff. 