### PR TITLE
Always return 6 chars long hex color

### DIFF
--- a/android/src/main/java/com/klarna/platformcolors/PlatformColorsModule.java
+++ b/android/src/main/java/com/klarna/platformcolors/PlatformColorsModule.java
@@ -30,8 +30,7 @@ public class PlatformColorsModule extends ReactContextBaseJavaModule {
 
   protected String getHexColor(@Nullable ReadableMap color) {
     int resolvedColor = ColorPropConverter.getColor(color, appContext);
-    String hexColor = Integer.toHexString(resolvedColor);
-    return "#" + hexColor.substring(2) + hexColor.substring(0, 2);
+    return String.format("#%06X", (0xFFFFFF & resolvedColor));
   }
 
   @ReactMethod

--- a/android/src/main/java/com/klarna/platformcolors/PlatformColorsModule.java
+++ b/android/src/main/java/com/klarna/platformcolors/PlatformColorsModule.java
@@ -30,7 +30,12 @@ public class PlatformColorsModule extends ReactContextBaseJavaModule {
 
   protected String getHexColor(@Nullable ReadableMap color) {
     int resolvedColor = ColorPropConverter.getColor(color, appContext);
-    return String.format("#%06X", (0xFFFFFF & resolvedColor));
+    int alpha = (resolvedColor >> 24) & 0xFF;
+    if (alpha == 0xFF) {
+      return String.format("#%06x", 0xFFFFFF & resolvedColor);
+    } else {
+      return String.format("#%06x%02x", 0xFFFFFF & resolvedColor, alpha);
+    }
   }
 
   @ReactMethod

--- a/ios/KLAPlatformColors.m
+++ b/ios/KLAPlatformColors.m
@@ -23,8 +23,13 @@ RCT_EXPORT_METHOD(resolveColor:(UIColor *)color
   CGFloat b = 0;
   CGFloat a = 0;
   [color getRed:&r green:&g blue:&b alpha:&a];
-  int rgb = (int)(r*255)<<16 | (int)(g*255)<<8 | (int)(b*255)<<0;
-  return [NSString stringWithFormat:@"#%06x", rgb];
+  int rgb = (int)(r * 0xFF) << 16 | (int)(g * 0xFF) << 8 | (int)(b * 0xFF) << 0;
+  int alpha = a * 0xFF;
+  if (alpha == 0xFF) {
+    return [NSString stringWithFormat:@"#%06x", rgb];
+  } else {
+    return [NSString stringWithFormat:@"#%06x%02x", rgb, alpha];
+  }
 }
 
 @end


### PR DESCRIPTION
This is inline with the iOS code path that already always returns 6 chars long hex colors. This avoids errors when feeding the return value back into Color.parseColor