### PR TITLE
Add colorset suffix to glob to prevent non-colorset files being removed

### DIFF
--- a/src/generate.js
+++ b/src/generate.js
@@ -16,7 +16,7 @@ async function generate(config) {
   const { outputDirectory } = config.ios;
   const prefix = formatName('ios', config);
 
-  const entries = await fg(`${path.join(outputDirectory, prefix)}*`, {
+  const entries = await fg(`${path.join(outputDirectory, prefix)}*.colorset`, {
     onlyFiles: false,
   });
 


### PR DESCRIPTION
If the iOS directory has non colorset-folder matching the prefix, the glob pattern will capture it and the following logic deletes this non-colorset folder.